### PR TITLE
Hyperlink enhancements: Editing URL, removing hyperlink (solves #35)

### DIFF
--- a/src/js/jquery.notebook.js
+++ b/src/js/jquery.notebook.js
@@ -389,11 +389,8 @@
                 });
                 var linkText = 'http://';
                 if(hasLink) {
-                    var anchor = utils.selection.getContainer(selection);
-                    if(anchor.nodeName.toLowerCase() != 'a') {
-                        anchor = $(anchor).closest('a');
-                    }
-                    linkText = $(anchor).prop('href') || linkText;
+                    var anchor = $(utils.selection.getContainer(selection)).closest('a');
+                    linkText = anchor.prop('href') || linkText;
                 }
                 $(this).parent().find('.link-area').show();
                 elem.val(linkText).focus();
@@ -589,12 +586,8 @@
                     bubble.update.call(this);
                 },
                 removeLink: function(e, s) {
-                    var el = utils.selection.getContainer(s);
-                    // Find anchor tag
-                    if(el.nodeName.toLowerCase() != 'a') {
-                        el = $(el).closest("a")[0];
-                    }
-                    $(el.firstChild).unwrap();
+                    var el = $(utils.selection.getContainer(s)).closest('a');
+                    el.contents().first().unwrap();
                 },
                 h1: function(e) {
                     e.preventDefault();


### PR DESCRIPTION
I've made two improvements to hyperlink editing: 
- When selecing a link and pressing the anchor button on the bubble, the existing address is pre-filled
- Added a way to remove a hyperlink. Currently this triggers when editing a link, clearing the address, and pressing enter.

This should resolve https://github.com/raphaelcruzeiro/jquery-notebook/issues/35

I also add `utils.selection.getContainer(selection)`, that should work cross-browser, and gets the element containing the selection.
