### PR TITLE
added -webkit-font-smoothing: antialiased;

### DIFF
--- a/src/js/jquery.notebook.css
+++ b/src/js/jquery.notebook.css
@@ -91,6 +91,7 @@
     color: white;
     font-size: 14pt;
     cursor: pointer;
+    -webkit-font-smoothing: antialiased;
 }
 
 .jquery-notebook.bubble button.active {


### PR DESCRIPTION
This makes the white-on-black text look much better on OSX, especially the icons.  Example: https://dl.dropboxusercontent.com/u/61997/jqnotebook.png  the bottom is the fix.
