### PR TITLE
changed attr to prop in modifier buttons

### DIFF
--- a/src/js/jquery.notebook.js
+++ b/src/js/jquery.notebook.js
@@ -324,7 +324,7 @@
                 var linkArea = utils.html.addTag(elem, 'div', false, false);
                 linkArea.addClass('link-area');
                 var linkInput = utils.html.addTag(linkArea, 'input', false, false);
-                linkInput.attr({
+                linkInput.prop({
                     type: 'text'
                 });
                 var closeBtn = utils.html.addTag(linkArea, 'button', false, false);


### PR DESCRIPTION
Re: http://stackoverflow.com/questions/5874652/prop-vs-attr

Using attr prevented the modifier buttons from appearing on a page I'm building. A change to prop fixed the issue!
