### PR TITLE
Fixes Paste Issues

### DIFF
--- a/src/js/jquery.notebook.js
+++ b/src/js/jquery.notebook.js
@@ -721,7 +721,8 @@
                 var elem = $(this),
                     id = 'jqeditor-temparea',
                     range = utils.selection.save(),
-                    tempArea = $('#' + id);
+                    tempArea = $('#' + id),
+                    self = this;
                 if (tempArea.length < 1) {
                     var body = $('body');
                     tempArea = $('<textarea></textarea>');
@@ -744,7 +745,7 @@
                     utils.selection.restore(range);
                     d.execCommand('delete');
                     d.execCommand('insertHTML', false, clipboardContent);
-                    events.change.call(this);
+                    events.change.call(self);
                 }, 500);
             },
             change: function(e) {


### PR DESCRIPTION
`events.change` is getting called with the `Window` object because it's being called in `setTimeout`. To get around the issue, I've aliased the original `this` value to `self` and `call`ed `event.change` with that alias instead. This should resolve issues regarding the paste functionality.
