### PR TITLE
issue 123: can't have multiple editors

### DIFF
--- a/src/js/jquery.notebook.js
+++ b/src/js/jquery.notebook.js
@@ -469,7 +469,7 @@
                 }
             },
             setContentArea: function(elem) {
-                var id = $('body').find('.jquery-editor').length + 1;
+                var id = $('body').find('.jquery-notebook').length + 1;
                 elem.attr('data-jquery-notebook-id', id);
                 var body = $('body');
                 contentArea = $('<textarea></textarea>');


### PR DESCRIPTION
Multiple editors all referenced the same hidden textarea.

Changed setContentArea function from:
    var id = $('body').find('.jquery-editor').length + 1;
To:
    var id = $('body').find('.jquery-notebook').length + 1;