### PR TITLE
Changed hidden paste textarea to fixed to prevent scrolling when pasting

### DIFF
--- a/src/js/jquery.notebook.js
+++ b/src/js/jquery.notebook.js
@@ -474,7 +474,7 @@
                 var body = $('body');
                 contentArea = $('<textarea></textarea>');
                 contentArea.css({
-                    position: 'absolute',
+                    position: 'fixed',
                     left: -1000
                 });
                 contentArea.attr('id', 'jquery-notebook-content-' + id);


### PR DESCRIPTION
When pasting into the notebook, content is written to a hidden textarea. The paste capturing script focuses on this textarea, which causes the browser to scroll to it (on the demo, the textarea is already in view, so you don't see this problem). Changing the textarea to fixed instead of absolute keeps it in view so the browser doesn't need to scroll.
