### PR TITLE
docs: Fix simple typo, aplications -> applications

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # jQuery-Notebook
-**A simple, clean and elegant WYSIWYG rich text editor for web aplications**  
+**A simple, clean and elegant WYSIWYG rich text editor for web applications**  
 **Note:** Check out the fully functional demo and examples [here](http://raphaelcruzeiro.github.io/jquery-notebook/).
 # Usage
 


### PR DESCRIPTION
There is a small typo in README.md.

Should read `applications` rather than `aplications`.

